### PR TITLE
Fix missing model registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,6 +258,7 @@ discord_token.txt
 
 # Model downloads
 models/
+!src/models/
 *.pth
 *.pt
 *.bin

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,10 @@
+"""Model registry and trainer implementations."""
+
+from .base_trainer import BaseTrainer, ModelRegistry, TrainingResult, InferenceResult
+
+# Import trainer implementations to register them if available
+try:
+    from .xtts.xtts_trainer import XTTSTrainer
+    ModelRegistry.register("xtts_v2", XTTSTrainer)
+except Exception:  # pragma: no cover - optional dependency may be missing
+    pass

--- a/src/models/base_trainer.py
+++ b/src/models/base_trainer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Base classes and registry for TTS models."""
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Type, List
+from abc import ABC, abstractmethod
+
+
+@dataclass
+class TrainingResult:
+    success: bool
+    model_path: Optional[str] = None
+    metrics: Optional[Dict[str, float]] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class InferenceResult:
+    success: bool
+    audio_path: Optional[str] = None
+    error: Optional[str] = None
+
+
+class BaseTrainer(ABC):
+    """Abstract base class for all model trainers."""
+
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        self.config_path = config_path
+
+    @abstractmethod
+    async def train(self, dataset_path: str, output_dir: str) -> TrainingResult:
+        """Train the model with the given dataset."""
+
+    @abstractmethod
+    async def synthesize(
+        self,
+        text: str,
+        reference_audio: Optional[str] = None,
+        output_path: Optional[str] = None,
+        streaming: bool = False,
+    ) -> InferenceResult:
+        """Generate speech from text."""
+
+
+class ModelRegistry:
+    """Registry for available model trainers."""
+
+    _registry: Dict[str, Type[BaseTrainer]] = {}
+
+    @classmethod
+    def register(cls, model_type: str, trainer_cls: Type[BaseTrainer]) -> None:
+        cls._registry[model_type] = trainer_cls
+
+    @classmethod
+    def get_trainer(cls, model_type: str) -> BaseTrainer:
+        if model_type not in cls._registry:
+            raise ValueError(f"Model not registered: {model_type}")
+        trainer_cls = cls._registry[model_type]
+        return trainer_cls()
+
+    @classmethod
+    def list_available_models(cls) -> List[str]:
+        return sorted(cls._registry.keys())
+
+    @classmethod
+    def detect_model_type(cls, identifier: str) -> str:
+        ident = identifier.lower()
+        if "xtts" in ident:
+            return "xtts_v2"
+        if "vits" in ident:
+            return "vits"
+        if "tortoise" in ident:
+            return "tortoise"
+        raise ValueError("Unable to detect model type")
+
+    @classmethod
+    def load_model(cls, model_type: str, identifier: str) -> BaseTrainer:
+        trainer = cls.get_trainer(model_type)
+        # Concrete trainers may implement actual loading logic. Here we just
+        # return the instantiated trainer.
+        return trainer

--- a/src/models/xtts/__init__.py
+++ b/src/models/xtts/__init__.py
@@ -1,0 +1,3 @@
+"""XTTS model implementation (placeholder)."""
+
+from .xtts_trainer import XTTSTrainer

--- a/src/models/xtts/xtts_trainer.py
+++ b/src/models/xtts/xtts_trainer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Placeholder XTTS trainer implementation."""
+
+import asyncio
+from typing import Optional
+
+from ..base_trainer import BaseTrainer, TrainingResult, InferenceResult
+
+
+class XTTSTrainer(BaseTrainer):
+    """Skeleton implementation of an XTTS trainer."""
+
+    async def train(self, dataset_path: str, output_dir: str) -> TrainingResult:
+        # Placeholder training logic
+        await asyncio.sleep(0)
+        return TrainingResult(success=False, error="Training not implemented")
+
+    async def synthesize(
+        self,
+        text: str,
+        reference_audio: Optional[str] = None,
+        output_path: Optional[str] = None,
+        streaming: bool = False,
+    ) -> InferenceResult:
+        # Placeholder synthesis logic
+        await asyncio.sleep(0)
+        return InferenceResult(success=False, error="Inference not implemented")


### PR DESCRIPTION
## Summary
- allow src/models to be tracked by git
- implement minimal model registry
- add placeholder XTTS trainer

## Testing
- `pytest -q -p no:cov --override-ini addopts=''` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684478a160b8832282faf8c722b382cf